### PR TITLE
improvements on handling E and PI constants - variable names like E1 and E_ are handled properly now

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -703,7 +703,7 @@ class Parser:
                     self.tokennumber = self.consts[i]
                     self.pos += L
                     return True
-                if not self.expression[self.pos + L].isalpha():
+                if not self.expression[self.pos + L].isalnum() and self.expression[self.pos + L] != "_":
                     self.tokennumber = self.consts[i]
                     self.pos += L
                     return True

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -83,6 +83,17 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(self.parser.parse('Engage').variables(), ["Engage"])
         self.assertEqual(self.parser.parse('Engage * PIE').variables(), ["Engage", "PIE"])
         self.assertEqual(self.parser.parse('Engage_').variables(), ["Engage_"])
+        self.assertEqual(self.parser.parse('Engage1').variables(), ["Engage1"])
+        self.assertEqual(self.parser.parse('E1').variables(), ["E1"])
+        self.assertEqual(self.parser.parse('PI2').variables(), ["PI2"])
+        self.assertEqual(self.parser.parse('(E1 + PI)').variables(), ["E1"])
+        self.assertEqual(self.parser.parse('E1_').variables(), ["E1_"])
+        self.assertEqual(self.parser.parse('E_').variables(), ["E_"])
+
+    def test_evaluating_consts(self):
+        self.assertEqual(self.parser.evaluate("Engage1", variables={"Engage1": 2}), 2)
+        self.assertEqual(self.parser.evaluate("Engage1 + 1", variables={"Engage1": 1}), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addition to fix for https://github.com/Axiacore/py-expression-eval/issues/9