### PR TITLE
bug when a string is empty (=='')

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -28,7 +28,7 @@ class Token():
         self.type_ = type_
         self.index_ = index_ or 0
         self.prio_ = prio_ or 0
-        self.number_ = number_ or 0
+        self.number_ = number_ if number_ != None else 0
 
     def toString(self):
         if self.type_ == TNUMBER:
@@ -727,7 +727,7 @@ class Parser:
             self.pos += 1
             while self.pos < len(self.expression):
                 code = self.expression[self.pos]
-                if code != '\'' or str[-1] == '\\':
+                if code != '\'' or (str != '' and str[-1] == '\\'):
                     str += self.expression[self.pos]
                     self.pos += 1
                 else:

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -80,6 +80,8 @@ class ParserTestCase(unittest.TestCase):
         self.assertIn("'a'=='b'",expr.toString())
         expr = parser.parse("concat('a\n','\n','\rb')=='a\n\n\rb'")
         self.assertEqual(expr.evaluate({}),True)
+        expr = parser.parse("a==''")
+        self.assertEqual(expr.evaluate({'a':''}),True)
 
         #test toString with an external function
         expr=parser.parse("myExtFn(a,b,c,1.51,'ok')")


### PR DESCRIPTION
Hi,
A simple bug correction that make the expression a=='' be evaluated correctly