### PR TITLE
Fix formatting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Out: '(-1.0+x)'
 
 Expression | Example | Output
 ---------- | ------- | ------ 
-+          | ``parser.parse('2 + 2').evaluate({})`` | 4.0
--          | ``parser.parse('3 - 1').evaluate({})`` | 2.0
-*          | ``parser.parse('2 * 3').evaluate({})`` | 6.0
+`+`          | ``parser.parse('2 + 2').evaluate({})`` | 4.0
+`-`          | ``parser.parse('3 - 1').evaluate({})`` | 2.0
+`*`          | ``parser.parse('2 * 3').evaluate({})`` | 6.0
 /          | ``parser.parse('5 / 2').evaluate({})`` | 2.5
 %          | ``parser.parse('5 % 2').evaluate({})`` | 1.0
 ^          | ``parser.parse('5 ^ 2').evaluate({})`` | 25.0

--- a/README.md
+++ b/README.md
@@ -80,28 +80,28 @@ Out: '(-1.0+x)'
 
 ### Available operators, constants and functions
 
-Expression | Example | Output
----------- | ------- | ------ 
-`+`          | ``parser.parse('2 + 2').evaluate({})`` | 4.0
-`-`          | ``parser.parse('3 - 1').evaluate({})`` | 2.0
-`*`          | ``parser.parse('2 * 3').evaluate({})`` | 6.0
-/          | ``parser.parse('5 / 2').evaluate({})`` | 2.5
-%          | ``parser.parse('5 % 2').evaluate({})`` | 1.0
-^          | ``parser.parse('5 ^ 2').evaluate({})`` | 25.0
-PI         | ``parser.parse('PI').evaluate({})`` | 3.141592653589793
-E          | ``parser.parse('E').evaluate({})`` | 2.718281828459045
-sin(x)     | ``parser.parse('sin(0)').evaluate({})`` | 0.0
-cos(x)     | ``parser.parse('cos(PI)').evaluate({})`` | - 1.0
-tan(x)     | ``parser.parse('tan(0)').evaluate({})`` | 0.0
-asin(x)     | ``parser.parse('asin(0)').evaluate({})`` | 0.0
-acos(x)     | ``parser.parse('acos(-1)').evaluate({})`` | 3.141592653589793
-atan(x)    | ``parser.parse('atan(PI)').evaluate({})`` | 1.2626272556789118
-log(x)    | ``parser.parse('log(1)').evaluate({})`` | 0.0
-abs(x)    | ``parser.parse('abs(-1)').evaluate({})`` | 1.0
-ceil(x)    | ``parser.parse('ceil(2.7)').evaluate({})`` | 3.0
-floor(x)    | ``parser.parse('floor(2.7)').evaluate({})`` | 2.0
-round(x)    | ``parser.parse('round(2.7)').evaluate({})`` | 3.0
-exp(x)    | ``parser.parse('exp(2)').evaluate({})`` | 7.38905609893065
+| Expression | Example | Output
+| ---------- | ------- | ------ 
+| +          | ``parser.parse('2 + 2').evaluate({})`` | 4.0
+| -          | ``parser.parse('3 - 1').evaluate({})`` | 2.0
+| `*`          | ``parser.parse('2 * 3').evaluate({})`` | 6.0
+| /          | ``parser.parse('5 / 2').evaluate({})`` | 2.5
+| %          | ``parser.parse('5 % 2').evaluate({})`` | 1.0
+| ^          | ``parser.parse('5 ^ 2').evaluate({})`` | 25.0
+| PI         | ``parser.parse('PI').evaluate({})`` | 3.141592653589793
+| E          | ``parser.parse('E').evaluate({})`` | 2.718281828459045
+| sin(x)     | ``parser.parse('sin(0)').evaluate({})`` | 0.0
+| cos(x)     | ``parser.parse('cos(PI)').evaluate({})`` | - 1.0
+| tan(x)     | ``parser.parse('tan(0)').evaluate({})`` | 0.0
+| asin(x)     | ``parser.parse('asin(0)').evaluate({})`` | 0.0
+| acos(x)     | ``parser.parse('acos(-1)').evaluate({})`` | 3.141592653589793
+| atan(x)    | ``parser.parse('atan(PI)').evaluate({})`` | 1.2626272556789118
+| log(x)    | ``parser.parse('log(1)').evaluate({})`` | 0.0
+| abs(x)    | ``parser.parse('abs(-1)').evaluate({})`` | 1.0
+| ceil(x)    | ``parser.parse('ceil(2.7)').evaluate({})`` | 3.0
+| floor(x)    | ``parser.parse('floor(2.7)').evaluate({})`` | 2.0
+| round(x)    | ``parser.parse('round(2.7)').evaluate({})`` | 3.0
+| exp(x)    | ``parser.parse('exp(2)').evaluate({})`` | 7.38905609893065
 
 ## Examples
 


### PR DESCRIPTION
The table of operators does not appear properly formatted when rendered on GitHub. I've added left-hand borders which correct this. Note that I'm wrapping the multiplication operator so that it does not appear as the left boundary of an emphasized section of text.