### PR TITLE
Support decimals beginning with only a dot

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -522,7 +522,9 @@ class Parser:
         while self.pos < len(self.expression):
             code = self.expression[self.pos]
             if (code >= '0' and code <= '9') or code == '.':
-                str += self.expression[self.pos]
+                if (len(str) == 0 and code == '.' ):
+                    str = '0'
+                str += code
                 self.pos += 1
                 self.tokennumber = float(str)
                 r = True

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -173,6 +173,18 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(parser.evaluate("count(inc)", variables={"inc": 5}), 5)
         self.assertEqual(parser.evaluate("count(inc)", variables={"inc": 5}), 10)
 
+    def test_decimals(self):
+        parser = Parser()
+
+        self.assertEqual(parser.parse(".1").evaluate({}), parser.parse("0.1").evaluate({}))
+        self.assertEqual(parser.parse(".1*.2").evaluate({}), parser.parse("0.1*0.2").evaluate({}))
+        self.assertEqual(parser.parse(".5^3").evaluate({}), float(0.125))
+        self.assertEqual(parser.parse("16^.5").evaluate({}), 4)
+        self.assertEqual(parser.parse("8300*.8").evaluate({}), 6640)
+
+        with self.assertRaises(ValueError):
+            parser.parse("..5").evaluate({})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds support for decimals like `.01`. Previously, the parser would crash at `isNumber` with a `ValueError: cannot convert '.' to float`. Now it understands this abbreviated way of specifying decimals.

Also added some tests for decimal numbers in varying expressions.