### PR TITLE
Adding log(n, base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Out: '(-1.0+x)'
 | acos(x)     | ``parser.parse('acos(-1)').evaluate({})`` | 3.141592653589793
 | atan(x)    | ``parser.parse('atan(PI)').evaluate({})`` | 1.2626272556789118
 | log(x)    | ``parser.parse('log(1)').evaluate({})`` | 0.0
+| log(x, base) | ``parser.parse('log(16, 2)').evaluate({})`` | 4.0
 | abs(x)    | ``parser.parse('abs(-1)').evaluate({})`` | 1
 | ceil(x)    | ``parser.parse('ceil(2.7)').evaluate({})`` | 3.0
 | floor(x)    | ``parser.parse('floor(2.7)').evaluate({})`` | 2.0

--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -312,7 +312,6 @@ class Parser:
             'acos': math.acos,
             'atan': math.atan,
             'sqrt': math.sqrt,
-            'log': math.log,
             'abs': abs,
             'ceil': math.ceil,
             'floor': math.floor,
@@ -343,6 +342,7 @@ class Parser:
         self.functions = {
             'random': random,
             'fac': self.fac,
+            'log': math.log,
             'min': min,
             'max': max,
             'pyt': self.pyt,

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -69,7 +69,9 @@ class ParserTestCase(unittest.TestCase):
         self.assertExactEqual(parser.parse('if(a>b,5,6)').evaluate({'a':8,'b':3}),5)
         self.assertExactEqual(parser.parse('if(a,b,c)').evaluate({'a':None,'b':1,'c':3}),3)
 
-
+        #log with base or natural log
+        self.assertExactEqual(parser.parse('log(16,2)').evaluate({}), 4.0)
+        self.assertExactEqual(parser.parse('log(E^100)').evaluate({}), 100.0)
 
         # test substitute
         expr = parser.parse('2 * x + 1')


### PR DESCRIPTION
This adds the capability of specifying a base when doing logarithm. The default is still to use natural log.