### PR TITLE
Don't treat double quotes as variables

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -607,11 +607,12 @@ class Parser:
         r = False
         str = ''
         startpos = self.pos
-        if self.pos < len(self.expression) and self.expression[self.pos] == "'":
+        if self.pos < len(self.expression) and self.expression[self.pos] in ("'", "\""):
+            quote_type = self.expression[self.pos]
             self.pos += 1
             while self.pos < len(self.expression):
                 code = self.expression[self.pos]
-                if code != '\'' or (str != '' and str[-1] == '\\'):
+                if code != quote_type or (str != '' and str[-1] == '\\'):
                     str += self.expression[self.pos]
                     self.pos += 1
                 else:

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -189,6 +189,20 @@ class ParserTestCase(unittest.TestCase):
         self.assertExactEqual(parser.evaluate("count(inc)", variables={"inc": 5}), 5)
         self.assertExactEqual(parser.evaluate("count(inc)", variables={"inc": 5}), 10)
 
+    def test_custom_functions_with_inline_strings(self):
+        parser = Parser()
+        expr = parser.parse("func(1, \"func(2, 4)\")")
+        self.assertEqual(expr.variables(), ['func'])
+
+    def test_custom_functions_substitute_strings(self):
+        def func(var, str):
+            if str == "custom text":
+                return 1
+            return 0
+        parser = Parser()
+        expr = parser.parse("func(1, \"custom text\")")
+        self.assertEqual(expr.evaluate({"func": func}), 1)
+    
     def test_decimals(self):
         parser = Parser()
 

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -30,8 +30,8 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(parser.parse('pow(x,y)').variables(), ['x','y'])
         self.assertEqual(parser.parse('pow(x,y)').symbols(), ['pow','x','y'])
 
-        #checking if '"a b"' could be a variable (using it in sql)
-        self.assertEqual(parser.parse('"a b"*2').evaluate({'"a b"':2}),4)
+        # but '"a b"' can *not* be used as a variable
+        self.assertEqual(parser.parse('"a b"*2').evaluate({'"a b"':2}),"a ba b")
 
         #evaluate
         self.assertExactEqual(parser.parse('1').evaluate({}), 1)


### PR DESCRIPTION
Single quotes and double quotes should be treated as the same thing. Making double quoted expressions treated as variables (as is the case right now) makes it impossible to deeply nest expressions (such as having something like `func(test, 'myfunc(\"test\",2,3)')`.

This is also the behavior of js-expression-eval -- so making this change would make it conformant with that library.