### PR TITLE
Add "not" and "xor" operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Out: '(-1.0+x)'
 | floor(x)    | ``parser.parse('floor(2.7)').evaluate({})`` | 2.0
 | round(x)    | ``parser.parse('round(2.7)').evaluate({})`` | 3.0
 | exp(x)    | ``parser.parse('exp(2)').evaluate({})`` | 7.38905609893065
+| and    | ``parser.parse('a and b').evaluate({'a':True, 'b':True})`` | True
+| or    | ``parser.parse('a or b').evaluate({'a':True, 'b':True})`` | True
+| xor    | ``parser.parse('a xor b').evaluate({'a':True, 'b':True})`` | False
+| not    | ``parser.parse('a and not b').evaluate({'a':True, 'b':True})`` | False
 
 ## Examples
 

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -14,7 +14,7 @@
 import unittest
 
 # from py_expression_eval import Parser
-from pyEval import Parser
+from py_expression_eval import Parser
 
 
 class ParserTestCase(unittest.TestCase):

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -13,7 +13,6 @@
 
 import unittest
 
-# from py_expression_eval import Parser
 from py_expression_eval import Parser
 
 


### PR DESCRIPTION
I originally requested the "not" operator be added. Someone kindly did it, but I tested it and it didn't work. I believe I have it working properly.  While I was at it, I added the "xor" function (exclusive OR).

I handled parsing for "not" in a manner similar to how "-" was handled. This required adding an "if" statement which the previous person missed. I also had to make adjustments to tokenprio to get the operator precedence correct. ("not" gets done before "and" which gets done before "or")

Note that Python only has a bitwise exclusive or operator with symbol "^" which is high on the priority ladder. Since this parser uses "^" for exponentiation, I used "xor" and made its priority the same as "or"

I noticed while working on this that the parser has multiplication and division with different priorities. In all languages I know, these have equal precedence. I didn't change it because someone may be using this package and changing this could change their results.

This is my first time ever making a Git pull request on someone else's repository. Please forgive me if I have messed up in some way. 