### PR TITLE
Make string literal quote types configurable

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -329,7 +329,9 @@ class Parser:
         a.append(b)
         return a
 
-    def __init__(self):
+    def __init__(self, string_literal_quotes = ("'", "\"")):
+        self.string_literal_quotes = string_literal_quotes
+
         self.success = False
         self.errormsg = ''
         self.expression = ''
@@ -662,7 +664,7 @@ class Parser:
         r = False
         str = ''
         startpos = self.pos
-        if self.pos < len(self.expression) and self.expression[self.pos] in ("'", "\""):
+        if self.pos < len(self.expression) and self.expression[self.pos] in self.string_literal_quotes:
             quote_type = self.expression[self.pos]
             self.pos += 1
             while self.pos < len(self.expression):


### PR DESCRIPTION
I'm looking to upgrade from v0.3.5 to latest. However, the changes in v0.3.9 (#47) break compatibility with existing functions my users have written, and aren't a good fit for my usecase where the keys in the values dict are human readable strings, frequently containing spaces.

This PR makes it trivial to opt out of the breaking change in 0.3.9.

Looks like others may also have encountered and/or would benefit from this too (#62, maybe even #38?)

If your happy with this added flexibility I'd really appreciate a 0.3.11 release with it in.