### PR TITLE
Removed unprintable character (0xC2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ expr.evaluate({'x': 2})  # 6.283185307179586
 # get variables
 expr = parser.parse('x * (y * atan(1))')
 expr.variables()  # ['x', 'y']
-expr.simplify({'y': 4}).variables()  # ['x']
+expr.simplify({'y': 4}).variables()  # ['x']
 ```
 
 Available operations


### PR DESCRIPTION
During installation I got an error regarding a character in README.md (`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 6031: ordinal not in range(128)`). 
It's on line 152: `expr.simplify({'y': 4}).variables()  # ['x']`
I can see the character in a hexadecimal view, but not in the diff view here. I removed it, now it installs fine.