### PR TITLE
Added support for integers in hexadecimal notation

### DIFF
--- a/py_expression_eval/__init__.py
+++ b/py_expression_eval/__init__.py
@@ -592,6 +592,13 @@ class Parser:
             self.tokennumber = float(match.group(1))
             return True
 
+        hex_pattern = r'(0x[0-9a-fA-F]+)'
+        match = re.match(hex_pattern, self.expression[self.pos: ])
+        if match:
+            self.pos += len(match.group(1))
+            self.tokennumber = int(match.group(1), base=16)
+            return True
+
         # number in decimal
         str = ''
         while self.pos < len(self.expression):

--- a/py_expression_eval/tests.py
+++ b/py_expression_eval/tests.py
@@ -261,6 +261,16 @@ class ParserTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             parser.parse("..5").evaluate({})
 
+    def test_hexadecimal(self):
+        parser = Parser()
+
+        self.assertExactEqual(parser.parse("0x4000").evaluate({}), 0x4000)
+        self.assertExactEqual(parser.parse("0x4000").evaluate({}), 16384)
+        self.assertExactEqual(parser.parse("0x3FF").evaluate({}), 0x3FF)
+        self.assertExactEqual(parser.parse("0x1000 * 2").evaluate({}), 0x2000)
+        self.assertExactEqual(parser.parse("1000 * 0x2").evaluate({}), 2000)
+        self.assertExactEqual(parser.parse("0x3F + 0x10 * 0x20 + 32").evaluate({}), 0x25F)
+
     def test_to_string(self):
         parser = Parser()
 


### PR DESCRIPTION
The added lines provide support for using integers in hexadecimal notation in
expressions. The code uses a regex to detect hexadecimal numbers.

Unit tests have been implemented to validate the implementation.